### PR TITLE
fix exports when importing as module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-module.exports = function diffState(newState, oldState) 
+var diffState = module.exports = function (newState, oldState) 
 {
   var patch = {};
 


### PR DESCRIPTION
While trying to use this module with a `import` statement, I encountered this error:

````js
ReferenceError: diffState is not defined
arrEqual
node_modules/diff-state/index.js:42

  39 |   // recurse into the nested arrays
  40 |   if (!arrEqual(arr1[i], arr2[i])) return false;
  41 | } else if (typeof arr1[i] === "object" && !Array.isArray(arr2[i])) {
> 42 |   if (diffState(arr1, arr2) !== undefined) return false; // Objects not equal
     | ^  43 | } else if (arr1[i] != arr2[i]) {
  44 |   return false; // Values are not equal
  45 | }
````

Not sure why it is happening exactly (`diffState` function should be in scope), but changing the export to a variable seems to fix it, which this PR contains.